### PR TITLE
Bugfix: Chapter 4 starter project SocketTimeoutException

### DIFF
--- a/04-data-layer-network/projects/starter/app/src/test/java/com/realworld/android/petsave/common/data/api/utils/JsonReader.kt
+++ b/04-data-layer-network/projects/starter/app/src/test/java/com/realworld/android/petsave/common/data/api/utils/JsonReader.kt
@@ -43,7 +43,7 @@ object JsonReader {
   fun getJson(path: String): String {
     return try {
       val context = InstrumentationRegistry.getInstrumentation().context
-      val jsonStream: InputStream = context.assets.open("networkresponses/$path")
+      val jsonStream: InputStream = context.assets.open(path)
       String(jsonStream.readBytes())
     } catch (exception: IOException) {
       Logger.e(exception, "Error reading network response json asset")


### PR DESCRIPTION
A pretty minor change but I was running into a `SocketTimeoutException` when following the code snippets in the book for the `AuthenticationInterceptorTest` in Chapter 4. The cause was that the expired token dispatcher given in the book (shown below) was including the `networkresponses` string which was also included in the `JsonReader` path for the starter project.

``` kotlin
private fun getDispatcherForExpiredToken() = object : Dispatcher() {
    override fun dispatch(request: RecordedRequest): MockResponse {
      return when (request.path) {
        authEndpointPath -> {
          MockResponse().setResponseCode(200).setBody(JsonReader.getJson("networkresponses/validToken.json"))
        }
        animalsEndpointPath -> { MockResponse().setResponseCode(200) }
        else -> { MockResponse().setResponseCode(404) }
      }
    }
  }
```

I went ahead and removed this duplicate string inside `JsonReader.kt` so it now matches the final project.

Here's a copy of the stack trace for completeness:
```
java.net.SocketTimeoutException: timeout
	at okio.SocketAsyncTimeout.newTimeoutException(JvmOkio.kt:146)
	at okio.AsyncTimeout.access$newTimeoutException(AsyncTimeout.kt:158)
	at okio.AsyncTimeout$source$1.read(AsyncTimeout.kt:337)
	at okio.RealBufferedSource.indexOf(RealBufferedSource.kt:427)
	at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:320)
	at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)
	at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:178)
	at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:106)
	at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:79)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at com.realworld.android.petsave.common.data.api.interceptors.AuthenticationInterceptor.proceedDeletingTokenIfUnauthorized(AuthenticationInterceptor.kt:122)
	at com.realworld.android.petsave.common.data.api.interceptors.AuthenticationInterceptor.refreshToken(AuthenticationInterceptor.kt:118)
	at com.realworld.android.petsave.common.data.api.interceptors.AuthenticationInterceptor.intercept(AuthenticationInterceptor.kt:74)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
	at com.realworld.android.petsave.common.data.api.interceptors.AuthenticationInterceptorTest.authenticatorInterceptor_expiredToken(AuthenticationInterceptorTest.kt:98)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:591)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:274)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:88)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.net.SocketTimeoutException: Read timed out
	at java.base/java.net.SocketInputStream.socketRead0(Native Method)
	at java.base/java.net.SocketInputStream.socketRead(SocketInputStream.java:115)
	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:168)
	at java.base/java.net.SocketInputStream.read(SocketInputStream.java:140)
	at okio.InputStreamSource.read(JvmOkio.kt:93)
	at okio.AsyncTimeout$source$1.read(AsyncTimeout.kt:125)
	... 40 more
``` 